### PR TITLE
Add SQLite persistence and global comms improvements

### DIFF
--- a/iot_curtain_automation/README.md
+++ b/iot_curtain_automation/README.md
@@ -1,16 +1,274 @@
-# iot_curtain_automation
+# GossipHome — IoT Curtain Automation App
 
-A new Flutter project.
+Flutter companion app for **GossipHome**, a CS7NS2 Internet of Things project at Trinity College Dublin (Group 12 — LSD LAB).
+
+The system automates curtains and windows across rooms using environmental triggers (sunlight, rain, temperature). ESP32 nodes communicate locally via a gossip protocol; this app provides remote visibility and control through a self-hosted MQTT broker.
+
+---
+
+## System Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│  ① Edge / Embedded Layer                                            │
+│  ESP32 nodes per room — sensors (DHT22, BH1750, rain, CO₂, PIR)   │
+│  and actuators (servo motors for curtains/windows)                  │
+│                    ↕ ESP-NOW / Wi-Fi+UDP                            │
+│  ② Local Comms — Gossip Protocol                                    │
+│  State propagation · Aggregation · Membership/health               │
+│                    ↕ MQTT over TLS                                  │
+│  ③ Global Comms — Balcony ESP32 Gateway                             │
+│  Publishes aggregated state · Subscribes to app commands/config     │
+│                    ↕ REST / WebSocket                               │
+│  ④ Self-Hosted Infrastructure                                       │
+│  Local MQTT broker · SQLite DB · Backend · This Flutter App         │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## MQTT Topic Schema (`gossiphome/`)
+
+### ESP32 → App (subscriptions)
+
+| Topic | Description |
+|---|---|
+| `gossiphome/rooms/{roomId}/state` | Aggregated room state (devices + sensors) |
+| `gossiphome/events` | High-level events (rain detected, sunlight, etc.) |
+| `gossiphome/gossip/metrics` | Gossip convergence metrics (convergence time, hop count, etc.) |
+| `gossiphome/gateway/heartbeat` | Gateway liveness ping |
+
+### App → ESP32 (publications)
+
+| Topic | Description |
+|---|---|
+| `gossiphome/commands/{roomId}/curtain` | Curtain position command |
+| `gossiphome/commands/{roomId}/window` | Window position command |
+| `gossiphome/config/thresholds` | User-configured automation thresholds |
+| `gossiphome/config/schedules` | Time-based schedules |
+
+### App status (Last Will Testament)
+
+| Topic | Description |
+|---|---|
+| `gossiphome/status/flutter_app` | Published `{"online":false}` by broker on unexpected app disconnect |
+
+---
+
+## Payload Formats
+
+### Room state (ESP32 publishes)
+
+```json
+{
+  "devices": {
+    "curtain": { "pos": 50, "moving": false, "online": true },
+    "window":  { "pos": 25, "moving": false, "online": true }
+  },
+  "sensors": {
+    "temp":       21.5,
+    "humidity":   60,
+    "light":      320,
+    "rain":       false,
+    "co2":        800,
+    "airQuality": 150
+  },
+  "online": true
+}
+```
+
+### Device command (App publishes)
+
+```json
+{
+  "action":   "set_position",
+  "position": 75,
+  "ts":       1708862400000
+}
+```
+
+### Thresholds (App publishes)
+
+```json
+{
+  "light_open_threshold":   500,
+  "light_close_threshold":  200,
+  "temp_ventilate":         25,
+  "rain_close_curtains":    true
+}
+```
+
+### Schedules (App publishes)
+
+```json
+{
+  "schedules": [
+    { "room_id": "bedroom", "action": "close", "hour": 22, "minute": 0 },
+    { "room_id": "living_room", "action": "open", "hour": 7, "minute": 30 }
+  ]
+}
+```
+
+### Gossip metrics (ESP32 gateway publishes)
+
+```json
+{
+  "convergence_ms":    120,
+  "hop_count":         3,
+  "propagation_rounds": 2,
+  "node_count":        4,
+  "ts":                1708862400000
+}
+```
+
+---
+
+## On-Device Database (SQLite)
+
+The app stores data locally using `sqflite`. Three tables are maintained:
+
+### `events`
+High-level events received on `gossiphome/events` and gossip metric snapshots. Used for post-hoc analysis and demo replay.
+
+| Column | Type | Notes |
+|---|---|---|
+| id | INTEGER PK | autoincrement |
+| room_id | TEXT | nullable (global events) |
+| type | TEXT | e.g. `rain_detected`, `gossip_metrics` |
+| data | TEXT | JSON blob |
+| ts | INTEGER | Unix ms |
+
+### `sensor_summaries`
+Rolling hourly aggregates per room and sensor type. Supports convergence experiment analysis (average, min, max, sample count per hour).
+
+| Column | Type | Notes |
+|---|---|---|
+| id | INTEGER PK | autoincrement |
+| room_id | TEXT | |
+| sensor_type | TEXT | `temp`, `humidity`, `light`, etc. |
+| avg_value | REAL | rolling average for the hour |
+| min_value | REAL | |
+| max_value | REAL | |
+| sample_count | INTEGER | |
+| hour_ts | INTEGER | Unix ms rounded to hour |
+
+### `config`
+Key/value store for user preferences and app configuration, persisted across sessions.
+
+| Column | Type | Notes |
+|---|---|---|
+| key | TEXT PK | |
+| value | TEXT | JSON blob |
+
+> **Web note:** `sqflite` is not supported on Flutter web. All `DatabaseService` methods are no-ops on web (`kIsWeb` guard).
+
+---
+
+## Global Comms Features
+
+### Auto-reconnect
+`MqttProvider` automatically retries the broker connection 10 seconds after an unexpected disconnect. Credentials (broker, port, username, password, TLS) are stored in memory for the session. User-initiated `disconnect()` disables auto-reconnect.
+
+### Gateway heartbeat
+The app subscribes to `gossiphome/gateway/heartbeat`. `MqttProvider.gatewayOnline` returns `true` if a heartbeat was received within the last 60 seconds.
+
+### Gossip metrics tracking
+Each `gossiphome/gossip/metrics` message is parsed into a `GossipMetrics` object (exposed as `MqttProvider.lastGossipMetrics`) and logged to the local `events` table for offline analysis. Fields: `convergenceMs`, `hopCount`, `propagationRounds`, `nodeCount`.
+
+### Last Will Testament
+The MQTT connection registers a LWT so the broker publishes `{"online":false}` to `gossiphome/status/flutter_app` if the app disconnects without a clean close.
+
+---
+
+## Project Structure
+
+```
+lib/
+├── core/
+│   └── theme/               # App theme (light + dark)
+├── data/
+│   ├── models/
+│   │   ├── device.dart      # Device (curtain/window), position 0–100
+│   │   ├── room.dart        # Room with devices + sensors
+│   │   └── sensor.dart      # Sensor types: temp, humidity, light, rain, CO₂, AQI
+│   └── services/
+│       ├── database_service.dart  # SQLite singleton — events, sensor_summaries, config
+│       └── mqtt_service.dart      # MqttService + MqttTopics + MqttMessageEvent
+└── presentation/
+    ├── providers/
+    │   ├── app_state_provider.dart  # UI state, room list, user preferences
+    │   └── mqtt_provider.dart       # MQTT connection, message routing, GossipMetrics
+    ├── screens/
+    │   ├── dashboard/   # Room grid overview
+    │   └── room/        # Per-room device controls + sensor readings
+    └── widgets/
+        ├── control_slider.dart  # Position slider for curtain/window
+        ├── room_card.dart       # Dashboard room summary card
+        └── sensor_tile.dart     # Sensor value display
+```
+
+---
 
 ## Getting Started
 
-This project is a starting point for a Flutter application.
+### Prerequisites
 
-A few resources to get you started if this is your first Flutter project:
+- Flutter SDK ≥ 3.10
+- A running MQTT broker on the local network (e.g. Mosquitto)
+- ESP32 nodes flashed with GossipHome firmware publishing to the topic schema above
 
-- [Lab: Write your first Flutter app](https://docs.flutter.dev/get-started/codelab)
-- [Cookbook: Useful Flutter samples](https://docs.flutter.dev/cookbook)
+### Run the app
 
-For help getting started with Flutter development, view the
-[online documentation](https://docs.flutter.dev/), which offers tutorials,
-samples, guidance on mobile development, and a full API reference.
+```bash
+flutter pub get
+flutter run
+```
+
+### Connect to the MQTT broker
+
+```dart
+context.read<MqttProvider>().connect(
+  broker: '192.168.1.x',  // IP of your local MQTT broker
+  port: 1883,             // 8883 for TLS
+  useTls: false,
+);
+```
+
+The broker address and port are persisted via `shared_preferences` and reloaded on next launch. The connection auto-reconnects if dropped.
+
+### Broker setup (Mosquitto example)
+
+```bash
+# Install
+brew install mosquitto   # macOS
+sudo apt install mosquitto mosquitto-clients   # Linux
+
+# Run with default config (no auth, port 1883)
+mosquitto -v
+```
+
+Once the ESP32 gateway starts publishing, rooms will appear in the app automatically — no manual room configuration needed.
+
+---
+
+## Privacy Design
+
+Gossip and raw sensor streams stay inside the home network. The broker (and this app) only ever see:
+
+- High-level events and aggregated summaries
+- User-configured thresholds and schedules
+- Gossip convergence metrics (timing + topology stats, no raw sensor values)
+
+Raw motion traces (PIR), per-second sensor readings, and the internal gossip state are never sent to the cloud.
+
+---
+
+## Team
+
+| Name | Roles |
+|---|---|
+| Pravigya Jain | Hardware · App Development |
+| Shreyansh Soni | App Development · Cloud |
+| Yokesh Muthu Kathivaran | Communication · Project Mgmt + AI |
+| Mohit Aggarwal | Communication · Cloud |
+| Rakesh Lakshmanan | Hardware · Project Mgmt + AI |

--- a/iot_curtain_automation/lib/data/services/database_service.dart
+++ b/iot_curtain_automation/lib/data/services/database_service.dart
@@ -1,0 +1,200 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:path/path.dart';
+import 'package:sqflite/sqflite.dart';
+
+class DatabaseService {
+  static const _dbName = 'gossiphome.db';
+  static const _dbVersion = 1;
+
+  Database? _db;
+
+  Future<Database?> get _database async {
+    if (kIsWeb) return null;
+    _db ??= await _open();
+    return _db;
+  }
+
+  Future<Database> _open() async {
+    final path = join(await getDatabasesPath(), _dbName);
+    return openDatabase(
+      path,
+      version: _dbVersion,
+      onCreate: (db, _) async {
+        await db.execute('''
+          CREATE TABLE events (
+            id        INTEGER PRIMARY KEY AUTOINCREMENT,
+            room_id   TEXT,
+            type      TEXT    NOT NULL,
+            data      TEXT    NOT NULL,
+            ts        INTEGER NOT NULL
+          )
+        ''');
+
+        await db.execute('''
+          CREATE TABLE sensor_summaries (
+            id           INTEGER PRIMARY KEY AUTOINCREMENT,
+            room_id      TEXT    NOT NULL,
+            sensor_type  TEXT    NOT NULL,
+            avg_value    REAL    NOT NULL,
+            min_value    REAL    NOT NULL,
+            max_value    REAL    NOT NULL,
+            sample_count INTEGER NOT NULL,
+            hour_ts      INTEGER NOT NULL,
+            UNIQUE (room_id, sensor_type, hour_ts)
+          )
+        ''');
+
+        await db.execute('''
+          CREATE TABLE config (
+            key   TEXT PRIMARY KEY,
+            value TEXT NOT NULL
+          )
+        ''');
+      },
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Events
+  // ---------------------------------------------------------------------------
+
+  Future<void> logEvent({
+    String? roomId,
+    required String type,
+    Map<String, dynamic> data = const {},
+  }) async {
+    final db = await _database;
+    if (db == null) return;
+    await db.insert('events', {
+      'room_id': roomId,
+      'type': type,
+      'data': jsonEncode(data),
+      'ts': DateTime.now().millisecondsSinceEpoch,
+    });
+  }
+
+  Future<List<Map<String, dynamic>>> recentEvents({
+    String? roomId,
+    int limit = 50,
+  }) async {
+    final db = await _database;
+    if (db == null) return [];
+    if (roomId != null) {
+      return db.query(
+        'events',
+        where: 'room_id = ?',
+        whereArgs: [roomId],
+        orderBy: 'ts DESC',
+        limit: limit,
+      );
+    }
+    return db.query('events', orderBy: 'ts DESC', limit: limit);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Sensor summaries (rolling hourly upsert)
+  // ---------------------------------------------------------------------------
+
+  Future<void> upsertSensorReading(
+    String roomId,
+    String sensorType,
+    double value,
+  ) async {
+    final db = await _database;
+    if (db == null) return;
+
+    final now = DateTime.now().millisecondsSinceEpoch;
+    final hourTs =
+        (now ~/ Duration.millisecondsPerHour) * Duration.millisecondsPerHour;
+
+    // Try to find an existing row for this hour.
+    final existing = await db.query(
+      'sensor_summaries',
+      where: 'room_id = ? AND sensor_type = ? AND hour_ts = ?',
+      whereArgs: [roomId, sensorType, hourTs],
+      limit: 1,
+    );
+
+    if (existing.isEmpty) {
+      await db.insert('sensor_summaries', {
+        'room_id': roomId,
+        'sensor_type': sensorType,
+        'avg_value': value,
+        'min_value': value,
+        'max_value': value,
+        'sample_count': 1,
+        'hour_ts': hourTs,
+      });
+    } else {
+      final row = existing.first;
+      final count = (row['sample_count'] as int) + 1;
+      final newAvg =
+          ((row['avg_value'] as double) * (count - 1) + value) / count;
+      final newMin = ((row['min_value'] as double) < value)
+          ? row['min_value'] as double
+          : value;
+      final newMax = ((row['max_value'] as double) > value)
+          ? row['max_value'] as double
+          : value;
+
+      await db.update(
+        'sensor_summaries',
+        {
+          'avg_value': newAvg,
+          'min_value': newMin,
+          'max_value': newMax,
+          'sample_count': count,
+        },
+        where: 'room_id = ? AND sensor_type = ? AND hour_ts = ?',
+        whereArgs: [roomId, sensorType, hourTs],
+      );
+    }
+  }
+
+  Future<List<Map<String, dynamic>>> sensorHistory(
+    String roomId,
+    String sensorType, {
+    int limitHours = 24,
+  }) async {
+    final db = await _database;
+    if (db == null) return [];
+    final cutoff = DateTime.now().millisecondsSinceEpoch -
+        limitHours * Duration.millisecondsPerHour;
+    return db.query(
+      'sensor_summaries',
+      where: 'room_id = ? AND sensor_type = ? AND hour_ts >= ?',
+      whereArgs: [roomId, sensorType, cutoff],
+      orderBy: 'hour_ts ASC',
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Config key/value store
+  // ---------------------------------------------------------------------------
+
+  Future<void> setConfig(String key, dynamic value) async {
+    final db = await _database;
+    if (db == null) return;
+    await db.insert(
+      'config',
+      {'key': key, 'value': jsonEncode(value)},
+      conflictAlgorithm: ConflictAlgorithm.replace,
+    );
+  }
+
+  Future<T?> getConfig<T>(String key) async {
+    final db = await _database;
+    if (db == null) return null;
+    final rows =
+        await db.query('config', where: 'key = ?', whereArgs: [key], limit: 1);
+    if (rows.isEmpty) return null;
+    return jsonDecode(rows.first['value'] as String) as T?;
+  }
+
+  Future<void> close() async {
+    await _db?.close();
+    _db = null;
+  }
+}

--- a/iot_curtain_automation/lib/data/services/mqtt_service.dart
+++ b/iot_curtain_automation/lib/data/services/mqtt_service.dart
@@ -1,42 +1,44 @@
 import 'dart:async';
+import 'dart:convert';
 
 import 'package:mqtt_client/mqtt_client.dart';
 import 'package:mqtt_client/mqtt_server_client.dart';
 
+/// Wraps an incoming MQTT message with its topic and decoded payload.
+class MqttMessageEvent {
+  final String topic;
+  final String payload;
+  const MqttMessageEvent(this.topic, this.payload);
+}
+
 class MqttService {
-  static const String _broker = 'your-aws-mqtt-broker.amazonaws.com';
-  static const int _port = 8883;
-  static const String _clientId = 'flutter_iot_client';
-  static const bool _useSSL = true;
+  static const int defaultPort = 1883;
+  static const String _clientId = 'gossiphome_flutter';
 
   late MqttServerClient _client;
   bool _isConnected = false;
-  final Map<String, void Function(String)> _subscriptions = {};
 
   final _connectionController = StreamController<bool>.broadcast();
-  final _messageController = StreamController<MqttMessage>.broadcast();
+  final _messageController = StreamController<MqttMessageEvent>.broadcast();
 
   Stream<bool> get connectionState => _connectionController.stream;
-  Stream<MqttMessage> get messages => _messageController.stream;
+  Stream<MqttMessageEvent> get messages => _messageController.stream;
 
   bool get isConnected => _isConnected;
 
   Future<bool> connect({
+    required String broker,
+    int port = defaultPort,
     String? username,
     String? password,
-    String? broker,
-    int? port,
+    bool useTls = false,
   }) async {
     try {
-      _client = MqttServerClient(
-        broker ?? _broker,
-        _clientId,
-      );
-
-      _client.port = port ?? _port;
+      _client = MqttServerClient(broker, _clientId);
+      _client.port = port;
       _client.logging(on: false);
       _client.keepAlivePeriod = 30;
-      _client.secure = _useSSL;
+      _client.secure = useTls;
       _client.onDisconnected = () {
         _isConnected = false;
         _connectionController.add(false);
@@ -45,23 +47,32 @@ class MqttService {
       final connMess = MqttConnectMessage()
           .withClientIdentifier(_clientId)
           .startClean()
+          .withWillTopic(MqttTopics.appStatus)
+          .withWillMessage('{"online":false}')
           .withWillQos(MqttQos.atLeastOnce);
-
       _client.connectionMessage = connMess;
 
       await _client.connect(username, password);
 
+      if (_client.connectionStatus?.state != MqttConnectionState.connected) {
+        return false;
+      }
+
       _isConnected = true;
       _connectionController.add(true);
 
-      _client.subscribe('#', MqttQos.atLeastOnce);
-      _client.updates?.listen((List<MqttReceivedMessage<MqttMessage?>> c) {
-        final MqttPublishMessage recMess = c[0].payload as MqttPublishMessage;
-        final String topic = c[0].topic;
-        final String pt =
-            MqttPublishPayload.bytesToStringAsString(recMess.payload.message);
+      _client.subscribe(MqttTopics.allRooms, MqttQos.atLeastOnce);
+      _client.subscribe(MqttTopics.events, MqttQos.atLeastOnce);
+      _client.subscribe(MqttTopics.gossipMetrics, MqttQos.atLeastOnce);
+      _client.subscribe(MqttTopics.gatewayHeartbeat, MqttQos.atLeastOnce);
 
-        _messageController.add(recMess);
+      _client.updates?.listen((List<MqttReceivedMessage<MqttMessage?>> msgs) {
+        for (final msg in msgs) {
+          final recMsg = msg.payload as MqttPublishMessage;
+          final payload = MqttPublishPayload.bytesToStringAsString(
+              recMsg.payload.message);
+          _messageController.add(MqttMessageEvent(msg.topic, payload));
+        }
       });
 
       return true;
@@ -80,28 +91,16 @@ class MqttService {
     }
   }
 
-  void publish(String topic, String message, {MqttQos qos = MqttQos.atLeastOnce}) {
+  /// Publish a JSON-serialisable map to [topic].
+  void publish(
+    String topic,
+    Map<String, dynamic> payload, {
+    MqttQos qos = MqttQos.atLeastOnce,
+  }) {
     if (!_isConnected) return;
-
     final builder = MqttClientPayloadBuilder();
-    builder.addString(message);
-
-    _client.publishMessage(
-      topic,
-      qos,
-      builder.payload!,
-    );
-  }
-
-  void subscribe(String topic, void Function(String message) callback) {
-    _subscriptions[topic] = callback;
-
-    _client.subscribe(topic, MqttQos.atLeastOnce);
-  }
-
-  void unsubscribe(String topic) {
-    _subscriptions.remove(topic);
-    _client.unsubscribe(topic);
+    builder.addString(jsonEncode(payload));
+    _client.publishMessage(topic, qos, builder.payload!);
   }
 
   void dispose() {
@@ -111,30 +110,39 @@ class MqttService {
   }
 }
 
-// MQTT Topics Structure
+// ---------------------------------------------------------------------------
+// Topic hierarchy for GossipHome
+// ---------------------------------------------------------------------------
 class MqttTopics {
-  // Base topics
-  static const String base = 'iot/curtain';
+  static const String _base = 'gossiphome';
 
-  // Device control topics
+  // ESP32 → App (subscriptions)
+  static String roomState(String roomId) => '$_base/rooms/$roomId/state';
+  static const String allRooms = '$_base/rooms/#';
+  static const String events = '$_base/events';
+  static const String gossipMetrics = '$_base/gossip/metrics';
+  static const String gatewayHeartbeat = '$_base/gateway/heartbeat';
+
+  // App → ESP32 (publications)
   static String curtainCommand(String roomId) =>
-      '$base/rooms/$roomId/curtain/command';
+      '$_base/commands/$roomId/curtain';
   static String windowCommand(String roomId) =>
-      '$base/rooms/$roomId/window/command';
+      '$_base/commands/$roomId/window';
+  static const String thresholds = '$_base/config/thresholds';
+  static const String schedules = '$_base/config/schedules';
 
-  // Device status topics
-  static String curtainStatus(String roomId) =>
-      '$base/rooms/$roomId/curtain/status';
-  static String windowStatus(String roomId) =>
-      '$base/rooms/$roomId/window/status';
+  // App status (Last Will Testament)
+  static const String appStatus = '$_base/status/flutter_app';
 
-  // Sensor data topics
-  static String sensorData(String roomId, String sensorType) =>
-      '$base/rooms/$roomId/sensors/$sensorType';
-
-  // Room status
-  static String roomStatus(String roomId) => '$base/rooms/$roomId/status';
-
-  // All rooms
-  static const String allRooms = '$base/rooms/#';
+  /// Extract roomId from e.g. 'gossiphome/rooms/bedroom/state' → 'bedroom'.
+  static String? roomIdFromStateTopic(String topic) {
+    final parts = topic.split('/');
+    if (parts.length == 4 &&
+        parts[0] == _base &&
+        parts[1] == 'rooms' &&
+        parts[3] == 'state') {
+      return parts[2];
+    }
+    return null;
+  }
 }

--- a/iot_curtain_automation/lib/main.dart
+++ b/iot_curtain_automation/lib/main.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import 'core/theme/app_theme.dart';
-import 'data/services/mqtt_service.dart';
+import 'data/services/database_service.dart';
 import 'presentation/providers/app_state_provider.dart';
 import 'presentation/providers/mqtt_provider.dart';
 import 'presentation/screens/dashboard/dashboard_screen.dart';
@@ -18,8 +18,18 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MultiProvider(
       providers: [
-        ChangeNotifierProvider(create: (_) => MqttProvider()),
+        // AppStateProvider must come first so MqttProvider can reference it.
         ChangeNotifierProvider(create: (_) => AppStateProvider()),
+        Provider<DatabaseService>(create: (_) => DatabaseService()),
+        ChangeNotifierProxyProvider2<AppStateProvider, DatabaseService,
+            MqttProvider>(
+          create: (_) => MqttProvider(),
+          update: (_, appState, db, mqttProvider) {
+            mqttProvider!.appStateProvider = appState;
+            mqttProvider.databaseService = db;
+            return mqttProvider;
+          },
+        ),
       ],
       child: MaterialApp(
         title: 'IoT Curtain Automation',

--- a/iot_curtain_automation/lib/presentation/providers/mqtt_provider.dart
+++ b/iot_curtain_automation/lib/presentation/providers/mqtt_provider.dart
@@ -1,150 +1,426 @@
 import 'dart:async';
+import 'dart:convert';
 
 import 'package:flutter/foundation.dart';
-import 'package:mqtt_client/mqtt_client.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 import '../../data/models/device.dart';
 import '../../data/models/room.dart';
+import '../../data/models/sensor.dart';
+import '../../data/services/database_service.dart';
 import '../../data/services/mqtt_service.dart';
+import 'app_state_provider.dart';
 
 class MqttProvider extends ChangeNotifier {
   final MqttService _mqttService = MqttService();
+
+  // Injected by ProxyProvider in main.dart
+  AppStateProvider? _appStateProvider;
+  DatabaseService? _databaseService;
+
   bool _isConnected = false;
+  bool _isConnecting = false;
   String? _errorMessage;
+  String _broker = '';
+  int _port = MqttService.defaultPort;
 
-  final List<Room> _rooms = [];
+  // Credentials kept for auto-reconnect
+  String? _lastUsername;
+  String? _lastPassword;
+  bool _lastUseTls = false;
+  bool _shouldAutoReconnect = false;
+  Timer? _reconnectTimer;
+  static const _reconnectDelay = Duration(seconds: 10);
 
-  // Stream subscriptions
+  // Gateway heartbeat
+  DateTime? _gatewayLastSeen;
+  static const _gatewayTimeoutSeconds = 60;
+
+  // Gossip metrics
+  GossipMetrics? _lastGossipMetrics;
+
   StreamSubscription<bool>? _connectionSubscription;
-  StreamSubscription<MqttMessage>? _messageSubscription;
+  StreamSubscription<MqttMessageEvent>? _messageSubscription;
 
   bool get isConnected => _isConnected;
+  bool get isConnecting => _isConnecting;
   String? get errorMessage => _errorMessage;
-  List<Room> get rooms => List.unmodifiable(_rooms);
+  String get broker => _broker;
+  int get port => _port;
+  DateTime? get gatewayLastSeen => _gatewayLastSeen;
+  bool get gatewayOnline =>
+      _gatewayLastSeen != null &&
+      DateTime.now().difference(_gatewayLastSeen!).inSeconds <
+          _gatewayTimeoutSeconds;
+  GossipMetrics? get lastGossipMetrics => _lastGossipMetrics;
+
+  set appStateProvider(AppStateProvider? provider) {
+    _appStateProvider = provider;
+  }
+
+  set databaseService(DatabaseService? db) {
+    _databaseService = db;
+  }
 
   MqttProvider() {
+    _loadSettings();
     _setupListeners();
   }
 
+  Future<void> _loadSettings() async {
+    final prefs = await SharedPreferences.getInstance();
+    _broker = prefs.getString('mqtt_broker') ?? '';
+    _port = prefs.getInt('mqtt_port') ?? MqttService.defaultPort;
+    notifyListeners();
+  }
+
+  Future<void> _saveSettings() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString('mqtt_broker', _broker);
+    await prefs.setInt('mqtt_port', _port);
+  }
+
   void _setupListeners() {
-    _connectionSubscription = _mqttService.connectionState.listen((isConnected) {
-      _isConnected = isConnected;
-      _errorMessage = isConnected ? null : 'Disconnected from MQTT broker';
+    _connectionSubscription =
+        _mqttService.connectionState.listen((connected) {
+      _isConnected = connected;
+      _isConnecting = false;
+      _errorMessage = connected ? null : 'Disconnected from broker';
+      if (!connected && _shouldAutoReconnect && _broker.isNotEmpty) {
+        _scheduleReconnect();
+      }
       notifyListeners();
     });
 
-    _messageSubscription = _mqttService.messages.listen((message) {
-      _handleMessage(message);
+    _messageSubscription = _mqttService.messages.listen(_handleMessage);
+  }
+
+  void _scheduleReconnect() {
+    _reconnectTimer?.cancel();
+    _reconnectTimer = Timer(_reconnectDelay, () async {
+      if (!_isConnected && _shouldAutoReconnect && _broker.isNotEmpty) {
+        _isConnecting = true;
+        notifyListeners();
+        await _mqttService.connect(
+          broker: _broker,
+          port: _port,
+          username: _lastUsername,
+          password: _lastPassword,
+          useTls: _lastUseTls,
+        );
+      }
     });
   }
 
   Future<bool> connect({
-    String? broker,
-    int? port,
+    required String broker,
+    int port = MqttService.defaultPort,
     String? username,
     String? password,
+    bool useTls = false,
   }) async {
+    _broker = broker;
+    _port = port;
+    _lastUsername = username;
+    _lastPassword = password;
+    _lastUseTls = useTls;
+    _shouldAutoReconnect = true;
+    _isConnecting = true;
     _errorMessage = null;
     notifyListeners();
+
+    await _saveSettings();
 
     final success = await _mqttService.connect(
       broker: broker,
       port: port,
       username: username,
       password: password,
+      useTls: useTls,
     );
 
+    _isConnecting = false;
     if (!success) {
-      _errorMessage = 'Failed to connect to MQTT broker';
+      _errorMessage = 'Failed to connect to $broker:$port';
       notifyListeners();
     }
-
     return success;
   }
 
   void disconnect() {
+    _shouldAutoReconnect = false;
+    _reconnectTimer?.cancel();
+    _reconnectTimer = null;
     _mqttService.disconnect();
   }
 
+  // ---------------------------------------------------------------------------
+  // Outbound commands (App → ESP32)
+  // ---------------------------------------------------------------------------
+
   void publishDeviceCommand(String roomId, String deviceType, int position) {
     if (!_isConnected) return;
-
     final topic = deviceType == 'curtain'
         ? MqttTopics.curtainCommand(roomId)
         : MqttTopics.windowCommand(roomId);
-
-    final command = {
+    _mqttService.publish(topic, {
       'action': 'set_position',
       'position': position,
-      'timestamp': DateTime.now().toIso8601String(),
-    };
-
-    _mqttService.publish(topic, command.toString());
+      'ts': DateTime.now().millisecondsSinceEpoch,
+    });
   }
 
-  void _handleMessage(MqttMessage message) {
-    if (message is! MqttPublishMessage) return;
-
-    final payload =
-        MqttPublishPayload.bytesToStringAsString(message.payload.message);
-
-    // TODO: Extract topic from message properly
-    // For now, we'll skip topic-based routing
-    // In production, you would use a wrapper that captures topics
-
-    // Process the message payload
-    _processPayload(payload);
+  void publishThresholds(Map<String, dynamic> thresholds) {
+    if (!_isConnected) return;
+    _mqttService.publish(MqttTopics.thresholds, thresholds);
   }
 
-  void _processPayload(String payload) {
-    // Parse the payload and update room state
-    // This is a simplified implementation
+  void publishSchedules(List<Map<String, dynamic>> schedules) {
+    if (!_isConnected) return;
+    _mqttService.publish(MqttTopics.schedules, {'schedules': schedules});
+  }
+
+  // ---------------------------------------------------------------------------
+  // Inbound message routing (ESP32 → App)
+  // ---------------------------------------------------------------------------
+
+  void _handleMessage(MqttMessageEvent event) {
     try {
-      // In production, parse JSON and update rooms
-      notifyListeners();
-    } catch (e) {
-      // Handle parsing errors
+      if (event.topic == MqttTopics.events) {
+        final data = jsonDecode(event.payload) as Map<String, dynamic>;
+        _databaseService?.logEvent(
+          roomId: data['room_id'] as String?,
+          type: (data['type'] as String?) ?? 'unknown',
+          data: data,
+        );
+        return;
+      }
+
+      if (event.topic == MqttTopics.gatewayHeartbeat) {
+        _gatewayLastSeen = DateTime.now();
+        notifyListeners();
+        return;
+      }
+
+      if (event.topic == MqttTopics.gossipMetrics) {
+        final data = jsonDecode(event.payload) as Map<String, dynamic>;
+        _lastGossipMetrics = GossipMetrics.fromJson(data);
+        _databaseService?.logEvent(
+          type: 'gossip_metrics',
+          data: data,
+        );
+        notifyListeners();
+        return;
+      }
+
+      final roomId = MqttTopics.roomIdFromStateTopic(event.topic);
+      if (roomId != null) {
+        _handleRoomState(roomId, event.payload);
+      }
+    } catch (_) {
+      // Non-fatal — malformed payload from a node
     }
   }
 
-  // Add a new room manually
-  void addRoom(Room room) {
-    _rooms.add(room);
-    notifyListeners();
-  }
+  /// Parse aggregated room state published by the ESP32 gateway.
+  ///
+  /// Expected payload:
+  /// ```json
+  /// {
+  ///   "devices": { "curtain": {"pos": 50, "moving": false, "online": true},
+  ///                "window":  {"pos": 25, "moving": false, "online": true} },
+  ///   "sensors": { "temp": 21.5, "humidity": 60, "light": 320,
+  ///                "rain": false, "co2": 800, "airQuality": 150 },
+  ///   "online": true
+  /// }
+  /// ```
+  void _handleRoomState(String roomId, String payload) {
+    final appState = _appStateProvider;
+    if (appState == null) return;
 
-  // Remove a room
-  void removeRoom(String roomId) {
-    _rooms.removeWhere((r) => r.id == roomId);
-    notifyListeners();
-  }
+    final json = jsonDecode(payload) as Map<String, dynamic>;
 
-  // Update a specific device
-  void updateDevice(String roomId, String deviceId, int position) {
-    final roomIndex = _rooms.indexWhere((r) => r.id == roomId);
-    if (roomIndex == -1) return;
+    Room? existing;
+    for (final r in appState.rooms) {
+      if (r.id == roomId) {
+        existing = r;
+        break;
+      }
+    }
 
-    final room = _rooms[roomIndex];
-    final deviceIndex = room.devices.indexWhere((d) => d.id == deviceId);
-    if (deviceIndex == -1) return;
+    final devices = _parseDevices(
+        roomId, json['devices'] as Map<String, dynamic>?, existing?.devices);
+    final sensors = _parseSensors(
+        roomId, json['sensors'] as Map<String, dynamic>?, existing?.sensors);
 
-    final updatedDevice = room.devices[deviceIndex].copyWith(
-      position: position,
+    final updated =
+        (existing ?? Room(id: roomId, name: _formatRoomName(roomId))).copyWith(
+      devices: devices,
+      sensors: sensors,
+      isOnline: json['online'] as bool? ?? true,
       lastUpdated: DateTime.now(),
     );
 
-    final updatedDevices = List<Device>.from(room.devices);
-    updatedDevices[deviceIndex] = updatedDevice;
+    if (existing != null) {
+      appState.updateRoom(updated);
+    } else {
+      appState.addRoom(updated);
+    }
 
-    _rooms[roomIndex] = room.copyWith(devices: updatedDevices);
-    notifyListeners();
+    // Persist numeric sensor readings for aggregation / history queries.
+    final db = _databaseService;
+    if (db != null) {
+      final sensorsJson = json['sensors'] as Map<String, dynamic>?;
+      sensorsJson?.forEach((key, value) {
+        if (value is num) {
+          db.upsertSensorReading(roomId, key, value.toDouble());
+        }
+      });
+    }
   }
+
+  List<Device> _parseDevices(
+    String roomId,
+    Map<String, dynamic>? devicesJson,
+    List<Device>? existing,
+  ) {
+    if (devicesJson == null) return existing ?? [];
+
+    final result = <Device>[];
+    devicesJson.forEach((typeKey, data) {
+      final d = data as Map<String, dynamic>;
+      final deviceType =
+          typeKey == 'curtain' ? DeviceType.curtain : DeviceType.window;
+
+      Device? existingDev;
+      if (existing != null) {
+        for (final dev in existing) {
+          if (dev.type == deviceType) {
+            existingDev = dev;
+            break;
+          }
+        }
+      }
+      existingDev ??= Device(
+        id: '${roomId}_$typeKey',
+        roomId: roomId,
+        name: _capitalise(typeKey),
+        type: deviceType,
+      );
+
+      result.add(existingDev.copyWith(
+        position: (d['pos'] as num?)?.toInt() ?? existingDev.position,
+        isMoving: d['moving'] as bool? ?? false,
+        isOnline: d['online'] as bool? ?? true,
+        lastUpdated: DateTime.now(),
+      ));
+    });
+    return result;
+  }
+
+  List<Sensor> _parseSensors(
+    String roomId,
+    Map<String, dynamic>? sensorsJson,
+    List<Sensor>? existing,
+  ) {
+    if (sensorsJson == null) return existing ?? [];
+
+    final result = <Sensor>[];
+    sensorsJson.forEach((key, value) {
+      final meta = _sensorMeta(key);
+      if (meta == null) return;
+      result.add(Sensor(
+        id: '${roomId}_$key',
+        roomId: roomId,
+        name: meta.name,
+        type: meta.type,
+        value: value,
+        unit: meta.unit,
+        isOnline: true,
+        lastUpdated: DateTime.now(),
+      ));
+    });
+    return result;
+  }
+
+  _SensorMeta? _sensorMeta(String key) {
+    switch (key) {
+      case 'temp':
+        return _SensorMeta(SensorType.temperature, 'Temperature', '°C');
+      case 'humidity':
+        return _SensorMeta(SensorType.humidity, 'Humidity', '%');
+      case 'light':
+        return _SensorMeta(SensorType.light, 'Light', 'lux');
+      case 'rain':
+        return _SensorMeta(SensorType.rain, 'Rain', '');
+      case 'co2':
+        return _SensorMeta(SensorType.co2, 'CO₂', 'ppm');
+      case 'airQuality':
+        return _SensorMeta(SensorType.airQuality, 'Air Quality', 'AQI');
+      default:
+        return null;
+    }
+  }
+
+  String _formatRoomName(String id) => id
+      .split('_')
+      .map((w) => w.isEmpty ? '' : w[0].toUpperCase() + w.substring(1))
+      .join(' ');
+
+  String _capitalise(String s) =>
+      s.isEmpty ? s : s[0].toUpperCase() + s.substring(1);
 
   @override
   void dispose() {
+    _reconnectTimer?.cancel();
     _connectionSubscription?.cancel();
     _messageSubscription?.cancel();
     _mqttService.dispose();
     super.dispose();
   }
+}
+
+// ---------------------------------------------------------------------------
+// Gossip metrics model
+// ---------------------------------------------------------------------------
+
+class GossipMetrics {
+  final int convergenceMs;
+  final int hopCount;
+  final int propagationRounds;
+  final int nodeCount;
+  final int ts;
+
+  const GossipMetrics({
+    required this.convergenceMs,
+    required this.hopCount,
+    required this.propagationRounds,
+    required this.nodeCount,
+    required this.ts,
+  });
+
+  factory GossipMetrics.fromJson(Map<String, dynamic> json) => GossipMetrics(
+        convergenceMs: (json['convergence_ms'] as num?)?.toInt() ?? 0,
+        hopCount: (json['hop_count'] as num?)?.toInt() ?? 0,
+        propagationRounds:
+            (json['propagation_rounds'] as num?)?.toInt() ?? 0,
+        nodeCount: (json['node_count'] as num?)?.toInt() ?? 0,
+        ts: (json['ts'] as num?)?.toInt() ??
+            DateTime.now().millisecondsSinceEpoch,
+      );
+
+  Map<String, dynamic> toJson() => {
+        'convergence_ms': convergenceMs,
+        'hop_count': hopCount,
+        'propagation_rounds': propagationRounds,
+        'node_count': nodeCount,
+        'ts': ts,
+      };
+}
+
+class _SensorMeta {
+  final SensorType type;
+  final String name;
+  final String unit;
+  const _SensorMeta(this.type, this.name, this.unit);
 }

--- a/iot_curtain_automation/pubspec.lock
+++ b/iot_curtain_automation/pubspec.lock
@@ -233,7 +233,7 @@ packages:
     source: hosted
     version: "1.0.0"
   path:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: path
       sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
@@ -357,6 +357,46 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.10.2"
+  sqflite:
+    dependency: "direct main"
+    description:
+      name: sqflite
+      sha256: e2297b1da52f127bc7a3da11439985d9b536f75070f3325e62ada69a5c585d03
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.2"
+  sqflite_android:
+    dependency: transitive
+    description:
+      name: sqflite_android
+      sha256: ecd684501ebc2ae9a83536e8b15731642b9570dc8623e0073d227d0ee2bfea88
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.2+2"
+  sqflite_common:
+    dependency: transitive
+    description:
+      name: sqflite_common
+      sha256: "6ef422a4525ecc601db6c0a2233ff448c731307906e92cabc9ba292afaae16a6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.6"
+  sqflite_darwin:
+    dependency: transitive
+    description:
+      name: sqflite_darwin
+      sha256: "279832e5cde3fe99e8571879498c9211f3ca6391b0d818df4e17d9fff5c6ccb3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.2"
+  sqflite_platform_interface:
+    dependency: transitive
+    description:
+      name: sqflite_platform_interface
+      sha256: "8dd4515c7bdcae0a785b0062859336de775e8c65db81ae33dd5445f35be61920"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.0"
   stack_trace:
     dependency: transitive
     description:
@@ -381,6 +421,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.1"
+  synchronized:
+    dependency: transitive
+    description:
+      name: synchronized
+      sha256: c254ade258ec8282947a0acbbc90b9575b4f19673533ee46f2f6e9b3aeefd7c0
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.4.0"
   term_glyph:
     dependency: transitive
     description:

--- a/iot_curtain_automation/pubspec.yaml
+++ b/iot_curtain_automation/pubspec.yaml
@@ -52,6 +52,10 @@ dependencies:
   # Local storage for settings
   shared_preferences: ^2.3.5
 
+  # On-device SQLite for event logs, sensor summaries, and user config
+  sqflite: ^2.4.2
+  path: ^1.9.1
+
   # Icons
   material_symbols_icons: ^4.2782.0
 


### PR DESCRIPTION
- Add sqflite/path deps; DatabaseService with events, sensor_summaries, config tables; kIsWeb no-op guard
- Inject DatabaseService via ChangeNotifierProxyProvider2 in main.dart
- MqttProvider: log events + upsert sensor readings to SQLite
- Subscribe to gossiphome/gossip/metrics and gossiphome/gateway/heartbeat
- Parse GossipMetrics (convergence_ms, hop_count, propagation_rounds, node_count); log each reading to events table
- Track gateway liveness via gatewayLastSeen / gatewayOnline (60 s timeout)
- Add publishSchedules() to complete the config publish API
- Last Will Testament: broker publishes {"online":false} on unexpected drop
- Auto-reconnect: retry after 10 s on unexpected disconnect
- Update README: new topics, payload formats, DB schema, feature docs